### PR TITLE
Use apex domain for GitHub Pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   title: 'DevRel Handbook',
   tagline: 'A concise and structured approach to Developer Relations',
-  url: 'https://www.devrelhandbook.com',
+  url: 'https://devrelhandbook.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-www.devrelhandbook.com
+devrelhandbook.com


### PR DESCRIPTION
## Summary
- update Docusaurus canonical URL to `https://devrelhandbook.com`
- update the Pages `CNAME` file to `devrelhandbook.com`

## Validation
- `npx --yes yarn@1.22.22 install --frozen-lockfile --silent && npx --yes yarn@1.22.22 build`